### PR TITLE
fix SETTINGS_PATH_FORMAT

### DIFF
--- a/res/scripts/client/gui/mods/mod_discord_rich_presence.py
+++ b/res/scripts/client/gui/mods/mod_discord_rich_presence.py
@@ -7,7 +7,7 @@ import traceback
 import BigWorld
 from gui.impl import backport
 from gui.impl.gen import R
-from helpers import i18n, dependency, getClientLanguage
+from helpers import i18n, dependency, getClientLanguage, getClientVersion
 from skeletons.gui.app_loader import IAppLoader, GuiGlobalSpaceID
 from CurrentVehicle import g_currentVehicle
 import ResMgr
@@ -41,8 +41,9 @@ def exceptions_decorate(func):
 
 
 def load_settings():
+    version = (getClientVersion()).split(' ')[0].replace('v.', '')
     DEFAULT_LANGUAGE = 'en'
-    SETTINGS_PATH_FORMAT = '../mods/configs/arukuka.discord_rich_presence/{}.json'
+    SETTINGS_PATH_FORMAT = '../mods/' + version + '/configs/arukuka.discord_rich_presence/{}.json'
 
     language = getClientLanguage()
     settings_json = read_file(SETTINGS_PATH_FORMAT.format(language))
@@ -291,4 +292,3 @@ def fini():
     global run_callbacks_thread
     if run_callbacks_thread is not None:
         run_callbacks_thread.join()
-


### PR DESCRIPTION
Hey, I just tried to use your mod and got this error in python.log:
```
2021-07-16 18:29:53.354: ERROR: Traceback (most recent call last):
2021-07-16 18:29:53.354: ERROR:   File ".\mod_discord_rich_presence.py", line 276, in init
2021-07-16 18:29:53.354: ERROR:   File ".\mod_discord_rich_presence.py", line 83, in __init__
2021-07-16 18:29:53.355: ERROR:   File ".\mod_discord_rich_presence.py", line 52, in load_settings
2021-07-16 18:29:53.355: ERROR: AttributeError: 'NoneType' object has no attribute 'encode'
```

I looked at [this line](https://github.com/arukuka/wotmods-discord-rich-presence/blob/3176e7afe014c9fd647aa840f606b39120ab218e/res/scripts/client/gui/mods/mod_discord_rich_presence.py#L52) and then I saw that you forgot the game version in `SETTINGS_PATH_FORMAT`, which causes the error. As a temporary fix, I hard-coded the version first and it worked, so I imported the helper to get the game version.

I hope I could help.