### PR TITLE
Write script to build XFM.Native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 2.7
+      - name: Set up .NET Core SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
       - name: Build
         env:
           TESTED_LATEST_WOT_VERSION: ${{ secrets.TESTED_LATEST_WOT_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.12
+        with:
+          cmake-version: '3.21.x'
       - name: Build
         env:
           TESTED_LATEST_WOT_VERSION: ${{ secrets.TESTED_LATEST_WOT_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/project.ini
+++ b/project.ini
@@ -3,5 +3,5 @@ wotmod_filename = arukuka.discord_rich_presence_@version@.wotmod
 zip_filename = arukuka.discord_rich_presence_@version@@additional_version@-@tested_latest_wot_version@.zip
 
 [depends]
-xfm_native_version = v2.2.0
+xfm_native_version = v2.6.0
 xfm_loader_version = 8.8.1

--- a/project.ini
+++ b/project.ini
@@ -4,4 +4,4 @@ zip_filename = arukuka.discord_rich_presence_@version@@additional_version@-@test
 
 [depends]
 xfm_native_version = v2.6.0
-xfm_loader_version = 8.8.1
+xfm_loader_version = 8.9.6

--- a/project.ini
+++ b/project.ini
@@ -1,4 +1,4 @@
-version = 0.1.4
+version = 0.1.5
 wotmod_filename = arukuka.discord_rich_presence_@version@.wotmod
 zip_filename = arukuka.discord_rich_presence_@version@@additional_version@-@tested_latest_wot_version@.zip
 

--- a/ps1_scripts/configure.ps1
+++ b/ps1_scripts/configure.ps1
@@ -25,7 +25,7 @@ $project_root_dir = Get-ProjectRootDir $project_root_dir -config $config
 
 $project_config = Get-ProjectConfig $ini_file -config $config -project_root_dir $project_root_dir
 
-$visual_studio = & "$vswhere" -prerelease -latest -products * -requires Microsoft.VisualStudio.Component.VC.CMake.Project -format json
+$visual_studio = & "$vswhere" -utf8 -prerelease -latest -products * -requires Microsoft.VisualStudio.Component.VC.CMake.Project -format json
 | ConvertFrom-Json
 
 # I'd like to unify build dirs between this and Visual Studio Code

--- a/ps1_scripts/prepare.ps1
+++ b/ps1_scripts/prepare.ps1
@@ -91,8 +91,8 @@ $config['xfm_native_root'] = $xfm_native_root
 $config['xfm_native_wotmod'] = $xfm_native_wotmod_path.FullName
 
 # Download XVM for getting xfm.loader
-$xvm_zip = "xvm-$($project_config.xfm_loader_version).zip"
-$xvm_download_url = "https://dl1.modxvm.com/bin/${xvm_zip}"
+$xvm_zip = "xvm_$($project_config.xfm_loader_version).zip"
+$xvm_download_url = "https://dl1.modxvm.com/release/${xvm_zip}"
 $xvm_zip = Join-Path $download_dir $xvm_zip
 Invoke-WebRequest -Uri $xvm_download_url -OutFile $xvm_zip
 $xvm_zip_info = [System.IO.FileInfo]$xvm_zip


### PR DESCRIPTION
[XFM.Native](https://gitlab.com/xvm/xfw/xfw.native) adds a tag for new version, but the release page seems to be no longer updated.  
Therefore, I changed it to build XFM.Native.  
The GitLab API doesn't seem to archive including the submodule, so it clones the repository.